### PR TITLE
Autodetect delimiter

### DIFF
--- a/.devel/sphinx/weave/how-to-access.Rmd
+++ b/.devel/sphinx/weave/how-to-access.Rmd
@@ -121,8 +121,8 @@ using CSV
 
 base_name = joinpath("~", "Projects", "clustering-data-v1", "wut", "smile")
 base_name = expanduser(base_name)
-data = CSV.read(base_name * ".data.gz", CSV.Tables.matrix; header=false, delim=' ')
-labels = CSV.read(base_name * ".labels0.gz", CSV.Tables.matrix; header=false, delim=' ')
+data = CSV.read(base_name * ".data.gz", CSV.Tables.matrix; header=false)
+labels = CSV.read(base_name * ".labels0.gz", CSV.Tables.matrix; header=false)
 ```
 
 


### PR DESCRIPTION
Do not fix delimiter to space, but let CSV.jl auto-detect the delimiter. Not all data is space-separated, e.g. fcps/wingnut is tab-separated. The previous code failed on that example.